### PR TITLE
make `rawloader` and `imagepipe` optional dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ readme = "./README.md"
 crate-type = ["cdylib", "rlib"]
 bench = false
 
+[features]
+default = ["read-raw-image"]
+read-raw-image = ["dep:imagepipe", "dep:rawloader"]
+
 [dependencies]
 image = "0.25.0"
 rayon = "1.10"
 kamadak-exif = "0.5.5"
-rawloader = "0.37"
-imagepipe = "0.5"
+rawloader = { version = "0.37", optional = true }
+imagepipe = { version = "0.5", optional = true }
 thiserror = "1.0.58"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Error definitions for the library
 
 use image::ImageError;
+#[cfg(feature = "read-raw-image")]
 use rawloader::RawLoaderError;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;
@@ -43,7 +44,12 @@ impl From<String> for UnknownError {
 pub enum Error {
     /// Represents image or raw image decoding error
     #[error("Unable to decode raw image")]
-    DecodeError(#[from] RawLoaderError),
+    #[cfg_attr(not(feature = "read-raw-image"), non_exhaustive)]
+    DecodeError(
+        #[from]
+        #[cfg(feature = "read-raw-image")]
+        RawLoaderError,
+    ),
     /// Represents raw image pipeline error
     #[error("Unable to decode raw image")]
     RawPipeline(#[from] RawPipelineError),

--- a/src/input.rs
+++ b/src/input.rs
@@ -23,7 +23,7 @@ impl HDRInput {
     ///
     /// * `path`: Path to file
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///
@@ -43,7 +43,7 @@ impl HDRInput {
     /// * `exposure`:
     /// * `gain`:
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///
@@ -67,7 +67,7 @@ impl HDRInput {
     /// * `exposure`:
     /// * `gain`:
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,6 +48,8 @@ impl HDRInput {
     /// # Errors
     ///
     /// - If image cannot be opened
+    /// - invalid gain
+    /// - invalid exposure duration
     pub fn with_exposure_and_gain(
         path: &String,
         exposure: Duration,
@@ -55,6 +57,23 @@ impl HDRInput {
     ) -> Result<Self, Error> {
         let image = read_image(path)?;
 
+        Self::with_image(image, exposure, gain)
+    }
+
+    ///
+    /// # Arguments
+    ///
+    /// * `image`:
+    /// * `exposure`:
+    /// * `gain`:
+    ///
+    /// returns: Result<HDRInput, Error>
+    ///
+    /// # Errors
+    ///
+    /// - invalid gain
+    /// - invalid exposure duration
+    pub fn with_image(image: DynamicImage, exposure: Duration, gain: f32) -> Result<Self, Error> {
         if gain.is_infinite() || gain.is_nan() || gain <= 0. {
             return Err(Error::InputError {
                 parameter_name: "gain".to_string(),
@@ -105,11 +124,7 @@ impl TryFrom<String> for HDRInput {
         let exposure = get_exposures(&exif)?;
         let gain = get_gains(&exif)?;
 
-        Ok(Self {
-            image,
-            exposure,
-            gain,
-        })
+        Self::with_image(image, Duration::from_secs_f32(exposure), gain)
     }
 }
 
@@ -139,6 +154,12 @@ impl HDRInputList {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+impl From<Vec<HDRInput>> for HDRInputList {
+    fn from(value: Vec<HDRInput>) -> Self {
+        Self(value)
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,9 +1,7 @@
 //! Helper functions to read and decode images
 
-use crate::error::{RawPipelineError, UnknownError};
 use crate::Error;
-use image::{DynamicImage, ImageBuffer, Rgb};
-use imagepipe::{ImageSource, Pipeline};
+use image::DynamicImage;
 
 /// Given a path to a file, attempt to read the image.
 /// The function supports reading raw images. All
@@ -15,14 +13,24 @@ use imagepipe::{ImageSource, Pipeline};
 pub(crate) fn read_image(path: &String) -> Result<DynamicImage, Error> {
     match image::open(path) {
         Ok(image) => Ok(image),
-        Err(_) => Ok(read_raw_image(path)?),
+        Err(_err) => {
+            #[cfg(not(feature = "read-raw-image"))]
+            return Err(_err.into());
+            #[cfg(feature = "read-raw-image")]
+            Ok(read_raw_image(path)?)
+        }
     }
 }
 
 /// Given a path to a file, attempt to read the RAW image.
 /// All formats and cameras supported by rawloader crate
 /// [rawloader](https://github.com/pedrocr/rawloader) are supported.
+#[cfg(feature = "read-raw-image")]
 pub(crate) fn read_raw_image(path: &String) -> Result<DynamicImage, Error> {
+    use crate::error::{RawPipelineError, UnknownError};
+    use image::{ImageBuffer, Rgb};
+    use imagepipe::{ImageSource, Pipeline};
+
     let raw = rawloader::decode_file(path)?;
 
     let source = ImageSource::Raw(raw);

--- a/src/stretch.rs
+++ b/src/stretch.rs
@@ -24,7 +24,7 @@ pub fn apply_histogram_stretch(image: &DynamicImage) -> Result<DynamicImage, Err
     let pixel_wise_channels = image_buffer
         .chunks_exact(3)
         .map(|chunk| -> Vec<f32> { chunk.to_vec() })
-        .collect();
+        .collect::<Vec<_>>();
 
     let channel_wise_pixels = transpose_vec(&pixel_wise_channels);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 /// Transposes a 2D Vector (Vec<Vec<Item>>)
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// let vec = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
 /// let result = transpose_vec(&vec);
 /// assert_eq!(result, vec![vec![1, 4, 7], vec![2, 5, 8], vec![3, 6, 9]]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@
 /// let result = transpose_vec(&vec);
 /// assert_eq!(result, vec![vec![1, 4, 7], vec![2, 5, 8], vec![3, 6, 9]]);
 /// ```
-pub(crate) fn transpose_vec<Item>(elements: &Vec<Vec<Item>>) -> Vec<Vec<Item>>
+pub(crate) fn transpose_vec<Item>(elements: &[Vec<Item>]) -> Vec<Vec<Item>>
 where
     Item: Copy,
 {
@@ -17,7 +17,7 @@ where
 
     let mut transformed: Vec<Vec<Item>> = vec![Vec::<Item>::with_capacity(image_count); capacity];
 
-    for element in elements.iter() {
+    for element in elements {
         for (inner_index, item) in element.iter().enumerate() {
             transformed[inner_index].push(*item);
         }


### PR DESCRIPTION
- add a way to create an `HDRInputList` from already loaded images via `HDRInput::new_image` and `impl From<Vec<HDRInput>> for HDRInputList`
  - this way no IO needs to be performed by `image-hdr` itself and already in-memory images don't need to be written to disk just to be loaded again
- make the ability to read raw-images optional, simply don't perform the fallback when the image crate fails to load an image
  - as a result `rawloader` and `imagepipe` can become optional dependencies, as such this has no longer any required LGPL licensed dependencies.