### PR TITLE
add example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,7 @@ kamadak-exif = "0.5.5"
 rawloader = { version = "0.37", optional = true }
 imagepipe = { version = "0.5", optional = true }
 thiserror = "1.0.58"
+
+[dev-dependencies]
+reqwest = { version = "0.12.5", features = ["blocking"] }
+image = { version = "0.25.0", features = ["jpeg"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,14 @@ readme = "./README.md"
 crate-type = ["cdylib", "rlib"]
 bench = false
 
+[features]
+default = ["read-raw-image"]
+read-raw-image = ["dep:imagepipe", "dep:rawloader"]
+
 [dependencies]
 image = "0.25.0"
 rayon = "1.10"
 kamadak-exif = "0.5.5"
-rawloader = "0.37"
-imagepipe = "0.5"
+rawloader = { version = "0.37", optional = true }
+imagepipe = { version = "0.5", optional = true }
 thiserror = "1.0.58"

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -1,0 +1,79 @@
+//! The example from the Readme.md
+//!
+//! Run with `cargo run --example readme_example --no-default-features`
+
+use std::{io::Read, time::Duration};
+
+use image_hdr::{
+    exif::{get_exif_data, get_exposures, get_gains},
+    input::HDRInput,
+    stretch::apply_histogram_stretch,
+};
+
+#[derive(Debug, thiserror::Error)]
+#[error("{0}")]
+enum Error {
+    Reqwest(#[from] reqwest::Error),
+    Io(#[from] std::io::Error),
+    Image(#[from] image::ImageError),
+    ImageHDR(#[from] image_hdr::Error),
+}
+
+fn main() -> Result<(), Error> {
+    let image_urls = [
+        (
+            "https://image-hdr-assets.s3.ap-south-1.amazonaws.com/DSC00001+Large.jpeg",
+            1.0 / 640.0,
+        ),
+        (
+            "https://image-hdr-assets.s3.ap-south-1.amazonaws.com/DSC00002+Large.jpeg",
+            1.0 / 4000.0,
+        ),
+        (
+            "https://image-hdr-assets.s3.ap-south-1.amazonaws.com/DSC00003+Large.jpeg",
+            1.0 / 80.0,
+        ),
+    ];
+
+    let mut images = Vec::with_capacity(image_urls.len());
+    let mut buf = Vec::new();
+    for (url, exposure) in image_urls {
+        let file_name = url.split("/").last().unwrap();
+
+        if !std::path::Path::exists(file_name.as_ref()) {
+            let mut response = reqwest::blocking::get(url)?;
+            println!("Downloading image: {url}");
+            let _ = response.read_to_end(&mut buf)?;
+            // we ignore failing to cache the image
+            let _ = std::fs::write(file_name, &buf);
+        } else {
+            println!("Using cached image: {url}");
+            let _ = std::fs::File::open(file_name)?.read_to_end(&mut buf)?;
+        }
+
+        let exif = get_exif_data(&buf)?;
+        let gains = get_gains(&exif).unwrap_or(1.0);
+        let exposure = get_exposures(&exif).unwrap_or(exposure);
+        println!("Loading image: {url}");
+        let image = image::load_from_memory_with_format(&buf, image::ImageFormat::Jpeg)?;
+        println!("Adding image: {url}");
+        dbg!(gains, exposure);
+        images.push(HDRInput::with_image(
+            image,
+            Duration::from_secs_f32(exposure),
+            gains,
+        )?);
+        buf.clear()
+    }
+
+    println!("Mergin images...");
+    let hdr_merged = image_hdr::hdr_merge_images(&images.into())?;
+    let stretched = apply_histogram_stretch(&hdr_merged)?;
+
+    println!("Saving merged image...");
+    stretched
+        .to_rgba16()
+        .save("./DSC00001-DSC00003+Large.tiff")?;
+
+    Ok(())
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 //! Error definitions for the library
 
 use image::ImageError;
+#[cfg(feature = "read-raw-image")]
 use rawloader::RawLoaderError;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;
@@ -43,7 +44,12 @@ impl From<String> for UnknownError {
 pub enum Error {
     /// Represents image or raw image decoding error
     #[error("Unable to decode raw image")]
-    DecodeError(#[from] RawLoaderError),
+    #[cfg_attr(not(feature = "read-raw-image"), non_exhaustive)]
+    DecodeError(
+        #[from]
+        #[cfg(feature = "read-raw-image")]
+        RawLoaderError,
+    ),
     /// Represents raw image pipeline error
     #[error("Unable to decode raw image")]
     RawPipeline(#[from] RawPipelineError),

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -3,16 +3,17 @@
 use crate::Error;
 use exif::{Exif, In, Tag, Value};
 
-pub(crate) fn get_exif_data(path: &String) -> Result<Exif, Error> {
-    let file = std::fs::File::open(path)?;
-    let mut buf_reader = std::io::BufReader::new(&file);
+/// Extract the exif information from the bytes of an image file
+pub fn get_exif_data(data: &[u8]) -> Result<Exif, Error> {
+    let mut buf_reader = std::io::Cursor::new(data);
     let exif_reader = exif::Reader::new();
     let exif = exif_reader.read_from_container(&mut buf_reader)?;
 
     Ok(exif)
 }
 
-pub(crate) fn get_exposures(exif: &Exif) -> Result<f32, Error> {
+/// Extract the exposure time in seconds from exif information
+pub fn get_exposures(exif: &Exif) -> Result<f32, Error> {
     match exif
         .get_field(Tag::ExposureTime, In::PRIMARY)
         .ok_or(Error::ExifError(exif::Error::NotFound(
@@ -25,8 +26,9 @@ pub(crate) fn get_exposures(exif: &Exif) -> Result<f32, Error> {
     }
 }
 
+/// Extract the gain from exif information
 #[allow(clippy::cast_precision_loss)]
-pub(crate) fn get_gains(exif: &Exif) -> Result<f32, Error> {
+pub fn get_gains(exif: &Exif) -> Result<f32, Error> {
     match exif
         .get_field(Tag::ISOSpeed, In::PRIMARY)
         .unwrap_or(

--- a/src/exif.rs
+++ b/src/exif.rs
@@ -4,6 +4,9 @@ use crate::Error;
 use exif::{Exif, In, Tag, Value};
 
 /// Extract the exif information from the bytes of an image file
+///
+/// # Errors
+/// - failed to extract exif data
 pub fn get_exif_data(data: &[u8]) -> Result<Exif, Error> {
     let mut buf_reader = std::io::Cursor::new(data);
     let exif_reader = exif::Reader::new();
@@ -13,6 +16,9 @@ pub fn get_exif_data(data: &[u8]) -> Result<Exif, Error> {
 }
 
 /// Extract the exposure time in seconds from exif information
+///
+/// # Errors
+/// - failed to exposure from exif data
 pub fn get_exposures(exif: &Exif) -> Result<f32, Error> {
     match exif
         .get_field(Tag::ExposureTime, In::PRIMARY)
@@ -26,7 +32,10 @@ pub fn get_exposures(exif: &Exif) -> Result<f32, Error> {
     }
 }
 
-/// Extract the gain from exif information
+/// Extract the gains from exif information
+///
+/// # Errors
+/// - failed to gains from exif data
 #[allow(clippy::cast_precision_loss)]
 pub fn get_gains(exif: &Exif) -> Result<f32, Error> {
     match exif

--- a/src/input.rs
+++ b/src/input.rs
@@ -174,7 +174,7 @@ impl<P: AsRef<Path> + Sync> TryFrom<&[P]> for HDRInputList {
             value
                 .par_iter()
                 .map(|value| -> Result<HDRInput, Self::Error> {
-                    Ok(HDRInput::try_from(value.as_ref())?)
+                    HDRInput::try_from(value.as_ref())
                 })
                 .collect::<Result<Vec<HDRInput>, Self::Error>>()?,
         ))

--- a/src/input.rs
+++ b/src/input.rs
@@ -57,7 +57,8 @@ impl HDRInput {
         gain: f32,
     ) -> Result<Self, Error> {
         let data = std::fs::read(path)?;
-        let image = read_image(&data)?;
+        let format = image::ImageFormat::from_path(path).ok();
+        let image = read_image(&data, format)?;
 
         Self::with_image(image, exposure, gain)
     }
@@ -122,7 +123,8 @@ impl TryFrom<&Path> for HDRInput {
 
     fn try_from(value: &Path) -> Result<Self, Self::Error> {
         let data = std::fs::read(value)?;
-        let image = read_image(&data)?;
+        let format = image::ImageFormat::from_path(value).ok();
+        let image = read_image(&data, format)?;
         let exif = get_exif_data(&data)?;
         let exposure = get_exposures(&exif)?;
         let gain = get_gains(&exif)?;

--- a/src/input.rs
+++ b/src/input.rs
@@ -23,7 +23,7 @@ impl HDRInput {
     ///
     /// * `path`: Path to file
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///
@@ -43,7 +43,7 @@ impl HDRInput {
     /// * `exposure`:
     /// * `gain`:
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///
@@ -67,7 +67,7 @@ impl HDRInput {
     /// * `exposure`:
     /// * `gain`:
     ///
-    /// returns: Result<HDRInput, Error>
+    /// returns: `Result<HDRInput, Error>`
     ///
     /// # Errors
     ///

--- a/src/input.rs
+++ b/src/input.rs
@@ -48,6 +48,8 @@ impl HDRInput {
     /// # Errors
     ///
     /// - If image cannot be opened
+    /// - invalid gain
+    /// - invalid exposure duration
     pub fn with_exposure_and_gain(
         path: &String,
         exposure: Duration,
@@ -55,6 +57,23 @@ impl HDRInput {
     ) -> Result<Self, Error> {
         let image = read_image(path)?;
 
+        Self::with_image(image, exposure, gain)
+    }
+
+    ///
+    /// # Arguments
+    ///
+    /// * `image`:
+    /// * `exposure`:
+    /// * `gain`:
+    ///
+    /// returns: Result<HDRInput, Error>
+    ///
+    /// # Errors
+    ///
+    /// - invalid gain
+    /// - invalid exposure duration
+    pub fn with_image(image: DynamicImage, exposure: Duration, gain: f32) -> Result<Self, Error> {
         if gain.is_infinite() || gain.is_nan() || gain <= 0. {
             return Err(Error::InputError {
                 parameter_name: "gain".to_string(),
@@ -105,11 +124,7 @@ impl TryFrom<String> for HDRInput {
         let exposure = get_exposures(&exif)?;
         let gain = get_gains(&exif)?;
 
-        Ok(Self {
-            image,
-            exposure,
-            gain,
-        })
+        Self::with_image(image, Duration::from_secs_f32(exposure), gain)
     }
 }
 
@@ -139,6 +154,12 @@ impl HDRInputList {
     #[must_use]
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+impl From<Vec<HDRInput>> for HDRInputList {
+    fn from(value: Vec<HDRInput>) -> Self {
+        Self(value)
     }
 }
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -10,8 +10,16 @@ use image::DynamicImage;
 ///
 /// # Errors
 /// If image cannot be read
-pub(crate) fn read_image(data: &[u8]) -> Result<DynamicImage, Error> {
-    match image::load_from_memory(data) {
+pub(crate) fn read_image(
+    data: &[u8],
+    format: Option<image::ImageFormat>,
+) -> Result<DynamicImage, Error> {
+    let load_result = match format {
+        Some(format) => image::load_from_memory_with_format(data, format),
+        None => image::load_from_memory(data),
+    };
+
+    match load_result {
         Ok(image) => Ok(image),
         Err(_err) => {
             #[cfg(not(feature = "read-raw-image"))]

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,9 +1,7 @@
 //! Helper functions to read and decode images
 
-use crate::error::{RawPipelineError, UnknownError};
 use crate::Error;
-use image::{DynamicImage, ImageBuffer, Rgb};
-use imagepipe::{ImageSource, Pipeline};
+use image::DynamicImage;
 
 /// Given a path to a file, attempt to read the image.
 /// The function supports reading raw images. All
@@ -15,14 +13,24 @@ use imagepipe::{ImageSource, Pipeline};
 pub(crate) fn read_image(path: &String) -> Result<DynamicImage, Error> {
     match image::open(path) {
         Ok(image) => Ok(image),
-        Err(_) => Ok(read_raw_image(path)?),
+        Err(_err) => {
+            #[cfg(not(feature = "read-raw-image"))]
+            return Err(_err.into());
+            #[cfg(feature = "read-raw-image")]
+            Ok(read_raw_image(path)?)
+        }
     }
 }
 
 /// Given a path to a file, attempt to read the RAW image.
 /// All formats and cameras supported by rawloader crate
 /// [rawloader](https://github.com/pedrocr/rawloader) are supported.
+#[cfg(feature = "read-raw-image")]
 pub(crate) fn read_raw_image(path: &String) -> Result<DynamicImage, Error> {
+    use crate::error::{RawPipelineError, UnknownError};
+    use image::{ImageBuffer, Rgb};
+    use imagepipe::{ImageSource, Pipeline};
+
     let raw = rawloader::decode_file(path)?;
 
     let source = ImageSource::Raw(raw);

--- a/src/io.rs
+++ b/src/io.rs
@@ -10,14 +10,14 @@ use image::DynamicImage;
 ///
 /// # Errors
 /// If image cannot be read
-pub(crate) fn read_image(path: &String) -> Result<DynamicImage, Error> {
-    match image::open(path) {
+pub(crate) fn read_image(data: &[u8]) -> Result<DynamicImage, Error> {
+    match image::load_from_memory(data) {
         Ok(image) => Ok(image),
         Err(_err) => {
             #[cfg(not(feature = "read-raw-image"))]
             return Err(_err.into());
             #[cfg(feature = "read-raw-image")]
-            Ok(read_raw_image(path)?)
+            Ok(read_raw_image(data)?)
         }
     }
 }
@@ -26,12 +26,12 @@ pub(crate) fn read_image(path: &String) -> Result<DynamicImage, Error> {
 /// All formats and cameras supported by rawloader crate
 /// [rawloader](https://github.com/pedrocr/rawloader) are supported.
 #[cfg(feature = "read-raw-image")]
-pub(crate) fn read_raw_image(path: &String) -> Result<DynamicImage, Error> {
+pub(crate) fn read_raw_image(data: &[u8]) -> Result<DynamicImage, Error> {
     use crate::error::{RawPipelineError, UnknownError};
     use image::{ImageBuffer, Rgb};
     use imagepipe::{ImageSource, Pipeline};
 
-    let raw = rawloader::decode_file(path)?;
+    let raw = rawloader::decode(&mut std::io::Cursor::new(data))?;
 
     let source = ImageSource::Raw(raw);
     let mut pipeline = Pipeline::new_from_source(source).map_err(RawPipelineError::from)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use image::{DynamicImage, GenericImageView, ImageBuffer};
 use poisson::calculate_poisson_estimate;
 
 pub mod error;
-mod exif;
+pub mod exif;
 pub mod input;
 mod io;
 mod poisson;

--- a/src/stretch.rs
+++ b/src/stretch.rs
@@ -24,7 +24,7 @@ pub fn apply_histogram_stretch(image: &DynamicImage) -> Result<DynamicImage, Err
     let pixel_wise_channels = image_buffer
         .chunks_exact(3)
         .map(|chunk| -> Vec<f32> { chunk.to_vec() })
-        .collect();
+        .collect::<Vec<_>>();
 
     let channel_wise_pixels = transpose_vec(&pixel_wise_channels);
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,7 @@
 /// Transposes a 2D Vector (Vec<Vec<Item>>)
 ///
 /// # Examples
-/// ```
+/// ```ignore
 /// let vec = vec![vec![1, 2, 3], vec![4, 5, 6], vec![7, 8, 9]];
 /// let result = transpose_vec(&vec);
 /// assert_eq!(result, vec![vec![1, 4, 7], vec![2, 5, 8], vec![3, 6, 9]]);

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,7 +8,7 @@
 /// let result = transpose_vec(&vec);
 /// assert_eq!(result, vec![vec![1, 4, 7], vec![2, 5, 8], vec![3, 6, 9]]);
 /// ```
-pub(crate) fn transpose_vec<Item>(elements: &Vec<Vec<Item>>) -> Vec<Vec<Item>>
+pub(crate) fn transpose_vec<Item>(elements: &[Vec<Item>]) -> Vec<Vec<Item>>
 where
     Item: Copy,
 {
@@ -17,7 +17,7 @@ where
 
     let mut transformed: Vec<Vec<Item>> = vec![Vec::<Item>::with_capacity(image_count); capacity];
 
-    for element in elements.iter() {
+    for element in elements {
         for (inner_index, item) in element.iter().enumerate() {
             transformed[inner_index].push(*item);
         }


### PR DESCRIPTION
This PR looks larger than it actually is as it is based on #2 only the fifth commit and beyond is new.

This adds the example from the `Readme.md` as a runable cargo example.

To facilitate this a few functions are now made public as they are quite convenient e.g. to extract exposure and gains from exif.

This shows how one might wan't to use image-hdr with an image already in memory (i.e. just downloaded).
As such some functions have been adjusted to work on a byte slice instead of taking a string and loading  the data from a file at the corresponding path.
We now try to get the file format from the file extension (as before) and otherwise fallback to guessing based on the file content (this is new).

Also functions that took a string to load an image not instead take a Path.
String converts trivially to Path and as such can still be used.

