### PR TITLE
disable image default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ ndarray = { version = "0.16.1", features = ["rayon"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.7", features = ["blocking"] }
-image = { version = "0.25.2", features = ["jpeg"] }
+image = { version = "0.25.2", features = ["jpeg", "tiff"] }
 
 [features]
 default = ["read-raw-image"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,17 @@ crate-type = ["cdylib", "rlib"]
 bench = false
 
 [dependencies]
-image = { version = "0.25.2", default-features = false }
+image = { version = "0.25.6", default-features = false }
 rayon = "1.10"
-kamadak-exif = "0.5.5"
+kamadak-exif = "0.6.1"
 rawloader = { version = "0.37", optional = true }
 imagepipe = { version = "0.5", optional = true }
-thiserror = "1.0.63"
+thiserror = "2.0.12"
 ndarray = { version = "0.16.1", features = ["rayon"] }
 
 [dev-dependencies]
-reqwest = { version = "0.12.7", features = ["blocking"] }
-image = { version = "0.25.2", default-features = false, features = [
+reqwest = { version = "0.12.15", features = ["blocking"] }
+image = { version = "0.25.6", default-features = false, features = [
     "jpeg",
     "tiff",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 bench = false
 
 [dependencies]
-image = "0.25.2"
+image = { version = "0.25.2", default-features = false }
 rayon = "1.10"
 kamadak-exif = "0.5.5"
 rawloader = { version = "0.37", optional = true }
@@ -26,7 +26,10 @@ ndarray = { version = "0.16.1", features = ["rayon"] }
 
 [dev-dependencies]
 reqwest = { version = "0.12.7", features = ["blocking"] }
-image = { version = "0.25.2", features = ["jpeg", "tiff"] }
+image = { version = "0.25.2", default-features = false, features = [
+    "jpeg",
+    "tiff",
+] }
 
 [features]
 default = ["read-raw-image"]

--- a/examples/readme_example.rs
+++ b/examples/readme_example.rs
@@ -40,7 +40,7 @@ fn main() -> Result<(), Error> {
     for (url, exposure) in image_urls {
         let file_name = url
             .split('/')
-            .last()
+            .next_back()
             .expect("Expected filename as last component in url");
 
         if std::path::Path::exists(file_name.as_ref()) {


### PR DESCRIPTION
- disable the default-features of the image dependency to fix #4 
- fixes the image dev-dependency declaration to include the tiff features as the example needs it
- upgrade dependencies, most significant segment change for
  - thiserror 1.0 -> 2.0
  - kamadak-exif 0.5 -> 0.6

